### PR TITLE
Add ability to collapse the experience header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,53 @@
   gap: 1.25rem;
 }
 
+.experience-header__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.experience-header__toggle,
+.experience-header__restore {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-glass);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.experience-header__toggle:hover,
+.experience-header__toggle:focus-visible,
+.experience-header__restore:hover,
+.experience-header__restore:focus-visible {
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+  border-color: var(--accent-400);
+  box-shadow: 0 10px 30px rgba(18, 21, 31, 0.16);
+}
+
+.experience-header__toggle span[aria-hidden],
+.experience-header__restore span[aria-hidden] {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.experience-header__restore {
+  position: sticky;
+  top: clamp(1rem, 2vw, 2.25rem);
+  background: var(--surface-elevated);
+  box-shadow: var(--shadow-soft);
+  color: var(--text-primary);
+  z-index: 9;
+}
+
 .experience-brand {
   display: flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ export default function App() {
   const [manualChapter, setManualChapter] = useState<string | null>(null);
   const [lastRun, setLastRun] = useState<{ you: string; opponent: string } | null>(null);
   const [debugOpen, setDebugOpen] = useState(false);
+  const [headerCollapsed, setHeaderCollapsed] = useState(false);
 
   const {
     appearance,
@@ -495,28 +496,57 @@ export default function App() {
   );
 
   return (
-    <div className="experience-shell" data-state={activeChapter}>
-      <header className="experience-header">
-        <div className="experience-header__top">
-          <div className="experience-brand">
-            <span className="experience-brand__pulse" aria-hidden />
-            <div>
-              <p className="micro-tag">Prep openings 2025</p>
-              <h1>Experience augmentee d'analyse d'ouvertures</h1>
+    <div
+      className="experience-shell"
+      data-state={activeChapter}
+      data-header={headerCollapsed ? "collapsed" : "expanded"}
+    >
+      {headerCollapsed ? (
+        <button
+          type="button"
+          className="experience-header__restore"
+          onClick={() => setHeaderCollapsed(false)}
+          aria-expanded="false"
+          aria-controls="experience-header"
+        >
+          <span aria-hidden>⌃</span>
+          <span>Afficher l'introduction</span>
+        </button>
+      ) : (
+        <header className="experience-header" id="experience-header">
+          <div className="experience-header__top">
+            <div className="experience-brand">
+              <span className="experience-brand__pulse" aria-hidden />
+              <div>
+                <p className="micro-tag">Prep openings 2025</p>
+                <h1>Experience augmentee d'analyse d'ouvertures</h1>
+              </div>
+            </div>
+            <div className="experience-header__controls">
+              <ExperienceToolbar
+                onToggleVoice={toggleVoiceListening}
+                voiceListening={voiceStatus === "listening"}
+                voiceSupported={voiceSupported}
+              />
+              <button
+                type="button"
+                className="experience-header__toggle"
+                onClick={() => setHeaderCollapsed(true)}
+                aria-expanded="true"
+                aria-controls="experience-header"
+              >
+                <span aria-hidden>×</span>
+                <span>Masquer l'introduction</span>
+              </button>
             </div>
           </div>
-          <ExperienceToolbar
-            onToggleVoice={toggleVoiceListening}
-            voiceListening={voiceStatus === "listening"}
-            voiceSupported={voiceSupported}
+          <JourneyNavigator
+            chapters={CHAPTERS}
+            activeId={activeChapter}
+            onSelect={handleChapterSelect}
           />
-        </div>
-        <JourneyNavigator
-          chapters={CHAPTERS}
-          activeId={activeChapter}
-          onSelect={handleChapterSelect}
-        />
-      </header>
+        </header>
+      )}
 
       <main className="experience-body">
         <section className="experience-story" aria-live="polite">


### PR DESCRIPTION
## Summary
- add UI state in the main experience shell to collapse or restore the header introduction
- include a close control alongside the toolbar and a sticky restore button when the header is hidden
- style the new controls to match the existing elevated surface appearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de66c7881c8327bed3fddd24118278