### PR TITLE
Improve French copy and accents across UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,15 +17,15 @@ const CHAPTERS: JourneyChapter[] = [
   {
     id: "context",
     label: "Brief",
-    title: "Prepare l'experience",
-    summary: "Personnalise l'ambiance, choisis ton theme, active le mode eco pour une empreinte legere.",
+    title: "Prépare l'expérience",
+    summary: "Personnalise l'ambiance, choisis ton thème, active le mode éco pour une empreinte légère.",
     icon: "🎯",
   },
   {
     id: "scouting",
     label: "Collecte",
-    title: "Scanning en temps reel",
-    summary: "Recuperation intelligente des parties recentes, IA qui filtre les signaux faibles.",
+    title: "Scan en temps réel",
+    summary: "Récupération intelligente des parties récentes, l'IA filtre les signaux faibles.",
     icon: "🔍",
   },
   {
@@ -38,8 +38,8 @@ const CHAPTERS: JourneyChapter[] = [
   {
     id: "prep",
     label: "Plan",
-    title: "Prep sheet augmente",
-    summary: "Fuites detectees, reponses recommandees, storytelling interactif pour memoriser.",
+    title: "Prep sheet augmentée",
+    summary: "Fuites détectées, réponses recommandées, storytelling interactif pour mémoriser.",
     icon: "🧠",
   },
 ];
@@ -47,9 +47,9 @@ const CHAPTERS: JourneyChapter[] = [
 const ACCENT_PRESETS = [
   { keywords: ["violet", "pourpre", "indigo"], hue: 248, label: "violet" },
   { keywords: ["corail", "rose", "magenta"], hue: 18, label: "corail" },
-  { keywords: ["emeraude", "vert", "jade"], hue: 150, label: "emeraude" },
+  { keywords: ["emeraude", "vert", "jade"], hue: 150, label: "émeraude" },
   { keywords: ["soleil", "or", "gold"], hue: 46, label: "solaire" },
-  { keywords: ["ocean", "bleu", "azur"], hue: 205, label: "ocean" },
+  { keywords: ["ocean", "bleu", "azur"], hue: 205, label: "océan" },
 ] as const;
 
 const DEFAULT_SUGGESTIONS = ["mode sombre", "chapitre analyse", "relance analyse"];
@@ -155,10 +155,10 @@ export default function App() {
         const opponentNodeCount = openingTree.opponent.byColor.white.length + openingTree.opponent.byColor.black.length;
         if (opponentNodeCount === 0) {
           const baseReason = openingTree.meta?.opponentCutoffApplied
-            ? "Pas assez de parties recentes pour dessiner un arbre"
-            : "Aucune partie exploitable meme en remontant l'historique";
+            ? "Pas assez de parties récentes pour dessiner un arbre"
+            : "Aucune partie exploitable même en remontant l'historique";
           const adjustments: string[] = [];
-          if (openingTree.meta?.opponentRelaxedWindow) adjustments.push("fenetre coups 4-16");
+          if (openingTree.meta?.opponentRelaxedWindow) adjustments.push("fenêtre coups 4-16");
           if (openingTree.meta?.opponentUsedFallback) adjustments.push("historique complet");
           const detailSuffix = adjustments.length ? ` Ajustements: ${adjustments.join(", ")}.` : "";
           setPrepError(`${baseReason}. (opp games: ${oppGames.length}, opp nodes: ${opponentNodeCount}).${detailSuffix}`);
@@ -194,7 +194,7 @@ export default function App() {
           explorer,
         });
         if (!sheet.leaks.length) {
-          setPrepError("Pas de fuite flagrante sur cette ligne, continue la preparation.");
+          setPrepError("Pas de fuite flagrante sur cette ligne, continue ta préparation.");
         }
         setPrepSheet(sheet);
       } catch (e: unknown) {
@@ -220,32 +220,32 @@ export default function App() {
       };
 
       if (!sanitized.trim()) {
-        return respond("Commande vide. Essaie mode sombre ou chapitre analyse.");
+        return respond("Commande vide. Essaie « mode sombre » ou « chapitre analyse ».");
       }
 
       if (includesAny("mode sombre", "mode nuit", "dark")) {
         if (appearance !== "dark") setAppearance("dark");
-        return respond("Theme nuit active.");
+        return respond("Thème nuit activé.");
       }
 
       if (includesAny("mode clair", "mode jour", "light")) {
         if (appearance !== "light") setAppearance("light");
-        return respond("Theme jour active.");
+        return respond("Thème jour activé.");
       }
 
       if (includesAny("mode auto", "automatique")) {
         if (appearance !== "auto") setAppearance("auto");
-        return respond("Theme auto synchronise.");
+        return respond("Thème auto synchronisé.");
       }
 
       if (includes("mode eco")) {
         const wantsDisable = includes("desactive") || includes("retire") || includes("coupe");
         if (wantsDisable) {
           if (ecoMode) toggleEcoMode();
-          return respond("Mode eco desactive.");
+          return respond("Mode éco désactivé.");
         }
         if (!ecoMode) toggleEcoMode();
-        return respond("Mode eco active.");
+        return respond("Mode éco activé.");
       }
 
       if (includesAny("motion douce", "animation douce", "calme", "slow")) {
@@ -255,41 +255,41 @@ export default function App() {
 
       if (includesAny("motion vive", "animation rapide", "dynamique")) {
         if (motion !== "dynamic") setMotion("dynamic");
-        return respond("Animations dynamiques activees.");
+        return respond("Animations dynamiques activées.");
       }
 
       if (includesAny("layout compact", "densite compacte", "compact", "dense")) {
         if (density !== "compact") setDensity("compact");
-        return respond("Layout compact active.");
+        return respond("Disposition compacte activée.");
       }
 
       if (includesAny("layout ample", "densite confortable", "confortable", "large")) {
         if (density !== "comfortable") setDensity("comfortable");
-        return respond("Layout ample active.");
+        return respond("Disposition ample activée.");
       }
 
       if (includesAny("couleur", "accent")) {
         for (const preset of ACCENT_PRESETS) {
           if (preset.keywords.some((keyword) => includes(keyword))) {
             if (accentHue !== preset.hue) setAccentHue(preset.hue);
-            return respond(`Accent ${preset.label} active.`);
+            return respond(`Accent ${preset.label} activé.`);
           }
         }
-        return respond("Dis une couleur: violet, corail, emeraude, solaire ou ocean.");
+        return respond("Dis une couleur : violet, corail, émeraude, solaire ou océan.");
       }
 
       if (includes("chapitre") || includes("section")) {
         if (includesAny("brief", "contexte")) {
           setManualChapter("context");
-          return respond("Chapitre brief affiche.");
+          return respond("Chapitre brief affiché.");
         }
         if (includesAny("collecte", "scout")) {
           setManualChapter("scouting");
-          return respond("Chapitre collecte active.");
+          return respond("Chapitre collecte activé.");
         }
         if (includes("analyse")) {
           setManualChapter("analysis");
-          return respond("Chapitre analyse active.");
+          return respond("Chapitre analyse activé.");
         }
         if (includesAny("plan", "prep", "preparation")) {
           setManualChapter("prep");
@@ -303,34 +303,34 @@ export default function App() {
           await run(lastRun.you, lastRun.opponent);
           return respond(`Je relance l'analyse pour ${lastRun.you} contre ${lastRun.opponent}.`);
         }
-        return respond("Aucune analyse memorisee.");
+        return respond("Aucune analyse mémorisée.");
       }
 
       if (includes("debug")) {
         const wantsClose = includes("ferme") || includes("masque") || includes("cache");
         if (wantsClose) {
           setDebugOpen(false);
-          return respond("Console debug masquee.");
+          return respond("Console debug masquée.");
         }
         setDebugOpen(true);
-        return respond("Console debug affichee.");
+        return respond("Console debug affichée.");
       }
 
       if (includes("assistant vocal") && includesAny("desactive", "coupe", "stop")) {
         if (voiceEnabled) toggleVoice();
-        return respond("Assistant vocal desactive.");
+        return respond("Assistant vocal désactivé.");
       }
 
       if (includes("assistant vocal") && includesAny("active", "demarre", "lance")) {
         if (!voiceEnabled) toggleVoice();
-        return respond("Assistant vocal active.");
+        return respond("Assistant vocal activé.");
       }
 
       if (includes("stop")) {
-        return respond("Micro coupe. Appuie sur le bouton pour reprendre.");
+        return respond("Micro coupé. Appuie sur le bouton pour reprendre.");
       }
 
-      return respond("Commande non reconnue. Essaie mode sombre ou chapitre analyse.");
+      return respond("Commande non reconnue. Essaie « mode sombre » ou « chapitre analyse ».");
     },
     [accentHue, appearance, density, ecoMode, lastRun, motion, run, setAccentHue, setAppearance, setDensity, setMotion, toggleEcoMode, toggleVoice, voiceEnabled]
   );
@@ -358,15 +358,15 @@ export default function App() {
 
   useEffect(() => {
     if (loading) {
-      setAssistantMessage("Je collecte les parties, respire.");
+      setAssistantMessage("Je collecte tes parties, respire.");
       return;
     }
     if (prepLoading) {
-      setAssistantMessage("Je cherche des modeles Lichess pertinents.");
+      setAssistantMessage("Je cherche des modèles Lichess pertinents.");
       return;
     }
     if (tree && !selectedNode) {
-      setAssistantMessage("Choisis une ligne pour creer ta prep sheet.");
+      setAssistantMessage("Choisis une ligne pour créer ta prep sheet.");
       return;
     }
     if (prepSheet && prepSheet.leaks.length === 0) {
@@ -374,7 +374,7 @@ export default function App() {
       return;
     }
     if (voiceStatus === "listening") {
-      setAssistantMessage("Je t'ecoute, demande un mode ou un chapitre.");
+      setAssistantMessage("Je t'écoute, demande un mode ou un chapitre.");
       return;
     }
     if (voiceStatus === "processing") {
@@ -452,7 +452,7 @@ export default function App() {
           <span aria-hidden>...</span>
           <div>
             <strong>Collecte Chess.com</strong>
-            <p>Je croise les parties recentes pour dresser le profil.</p>
+            <p>Je croise tes parties récentes pour dresser le profil.</p>
           </div>
         </div>
       )}
@@ -470,7 +470,7 @@ export default function App() {
           <span aria-hidden>??</span>
           <div>
             <strong>Explorer Lichess</strong>
-            <p>Je recupere la theorie recente et des modeles.</p>
+            <p>Je récupère la théorie récente et des modèles.</p>
           </div>
         </div>
       )}
@@ -488,7 +488,7 @@ export default function App() {
           <span aria-hidden>^^</span>
           <div>
             <strong>Entre deux pseudos</strong>
-            <p>On reconstruira la cartographie d'ouvertures recente.</p>
+            <p>On reconstruira la cartographie d'ouvertures récente.</p>
           </div>
         </div>
       )}
@@ -518,8 +518,8 @@ export default function App() {
             <div className="experience-brand">
               <span className="experience-brand__pulse" aria-hidden />
               <div>
-                <p className="micro-tag">Prep openings 2025</p>
-                <h1>Experience augmentee d'analyse d'ouvertures</h1>
+                <p className="micro-tag">Prépa openings 2025</p>
+                <h1>Expérience augmentée d'analyse d'ouvertures</h1>
               </div>
             </div>
             <div className="experience-header__controls">
@@ -556,11 +556,11 @@ export default function App() {
                 return (
                   <article className="story-card">
                     <h2>Scouting automatique</h2>
-                    <p>L'IA filtre les parties recentes, detecte les signaux faibles et respecte la sobriete numerique.</p>
+                    <p>L'IA filtre tes parties récentes, détecte les signaux faibles et respecte la sobriété numérique.</p>
                     <ul>
-                      <li>Fenetre temporelle dynamique</li>
-                      <li>Fallback historique controle</li>
-                      <li>Data publique uniquement</li>
+                      <li>Fenêtre temporelle dynamique</li>
+                      <li>Historique de secours contrôlé</li>
+                      <li>Données publiques uniquement</li>
                     </ul>
                   </article>
                 );
@@ -568,11 +568,11 @@ export default function App() {
                 return (
                   <article className="story-card">
                     <h2>Navigation innovante</h2>
-                    <p>Scroll vertical pour les chapitres, horizontal pour zoomer dans la ligne. Halos et micro animations.</p>
+                    <p>Scroll vertical pour les chapitres, horizontal pour zoomer dans la ligne. Halos et micro-animations.</p>
                     <ul>
-                      <li>Micro interactions clavier et tactile</li>
+                      <li>Micro-interactions clavier et tactile</li>
                       <li>Visualisation abstraite au lieu de tableaux</li>
-                      <li>Personnalisation motion et densite</li>
+                      <li>Personnalise animations et densité</li>
                     </ul>
                   </article>
                 );
@@ -580,10 +580,10 @@ export default function App() {
                 return (
                   <article className="story-card">
                     <h2>Storytelling interactif</h2>
-                    <p>Chaque fuite devient un scenario: score adverse, ripostes, parties modeles et badges engages.</p>
+                    <p>Chaque fuite devient un scénario : score adverse, ripostes, parties modèles et badges engagés.</p>
                     <ul>
-                      <li>Badges gamifies en temps reel</li>
-                      <li>Mode sombre optimise</li>
+                      <li>Badges gamifiés en temps réel</li>
+                      <li>Mode sombre optimisé</li>
                       <li>Assistant vocal accessible</li>
                     </ul>
                   </article>
@@ -591,12 +591,12 @@ export default function App() {
               default:
                 return (
                   <article className="story-card">
-                    <h2>Experience personnalisee</h2>
-                    <p>Choisis ton ambiance, active l'assistant, adapte la charge visuelle et garde le controle de tes donnees.</p>
+                    <h2>Expérience personnalisée</h2>
+                    <p>Choisis ton ambiance, active l'assistant, allège la charge visuelle et garde le contrôle de tes données.</p>
                     <ul>
-                      <li>Accessibilite WCAG 2.2</li>
-                      <li>Mode eco et assets legers</li>
-                      <li>Palette emotionnelle modulable</li>
+                      <li>Accessibilité WCAG 2.2</li>
+                      <li>Mode éco et assets légers</li>
+                      <li>Palette émotionnelle modulable</li>
                     </ul>
                   </article>
                 );
@@ -701,16 +701,16 @@ export default function App() {
 
       <footer className="experience-footer">
         <div>
-          <strong>Respect et durabilite</strong>
-          <p>Empreinte suivie, dark mode optimise, ressources compressees. Tu gardes la main sur tes donnees.</p>
+          <strong>Respect et durabilité</strong>
+          <p>Empreinte suivie, dark mode optimisé, ressources compressées. Tu gardes la main sur tes données.</p>
         </div>
         <div>
-          <strong>Accessibilite</strong>
-          <p>Contrastes eleves, zones cliquables genereuses, navigation vocale et textes alternatifs.</p>
+          <strong>Accessibilité</strong>
+          <p>Contrastes élevés, zones cliquables généreuses, navigation vocale et textes alternatifs.</p>
         </div>
         <div>
           <strong>Gamification responsable</strong>
-          <p>Badges relies a la progression, feedback instantane, classement optionnel.</p>
+          <p>Badges reliés à la progression, feedback instantané, classement optionnel.</p>
         </div>
       </footer>
     </div>

--- a/src/ui/components/ExperienceToolbar.tsx
+++ b/src/ui/components/ExperienceToolbar.tsx
@@ -32,20 +32,20 @@ export function ExperienceToolbar({ onToggleVoice, voiceListening, voiceSupporte
     ? voiceListening
       ? "Assistant vocal actif"
       : voiceEnabled
-        ? "Assistant vocal pret"
-        : "Assistant vocal desactive"
-    : "Assistant vocal non supporte";
+        ? "Assistant vocal prêt"
+        : "Assistant vocal désactivé"
+    : "Assistant vocal non supporté";
 
   return (
-    <div className="experience-toolbar" role="group" aria-label="Preferences d'experience">
+    <div className="experience-toolbar" role="group" aria-label="Préférences d'expérience">
       <button
         type="button"
         className="toolbar-chip"
         onClick={cycleTheme}
-        aria-label={`Changer le theme, actuel : ${appearance}`}
+        aria-label={`Changer le thème, actuel : ${appearance}`}
       >
         <span aria-hidden>*</span>
-        <span>{appearance === "auto" ? "Theme auto" : appearance === "dark" ? "Theme nuit" : "Theme jour"}</span>
+        <span>{appearance === "auto" ? "Thème auto" : appearance === "dark" ? "Thème nuit" : "Thème jour"}</span>
       </button>
 
       <label className="toolbar-slider" aria-label="Changer la couleur d'accent">
@@ -66,7 +66,7 @@ export function ExperienceToolbar({ onToggleVoice, voiceListening, voiceSupporte
         aria-pressed={motion === "dynamic"}
       >
         <span aria-hidden>+</span>
-        <span>{motion === "dynamic" ? "Motion vive" : "Motion douce"}</span>
+        <span>{motion === "dynamic" ? "Animations vives" : "Animations douces"}</span>
       </button>
 
       <button
@@ -76,7 +76,7 @@ export function ExperienceToolbar({ onToggleVoice, voiceListening, voiceSupporte
         aria-pressed={density === "comfortable"}
       >
         <span aria-hidden>=</span>
-        <span>{density === "comfortable" ? "Layout ample" : "Layout dense"}</span>
+        <span>{density === "comfortable" ? "Disposition ample" : "Disposition dense"}</span>
       </button>
 
       <button
@@ -86,7 +86,7 @@ export function ExperienceToolbar({ onToggleVoice, voiceListening, voiceSupporte
         aria-pressed={ecoMode}
       >
         <span aria-hidden>!</span>
-        <span>{ecoMode ? "Mode eco" : "Energie"}</span>
+        <span>{ecoMode ? "Mode éco" : "Énergie"}</span>
       </button>
 
       <button
@@ -97,7 +97,7 @@ export function ExperienceToolbar({ onToggleVoice, voiceListening, voiceSupporte
         disabled={!voiceSupported}
       >
         <span aria-hidden>~</span>
-        <span>{voiceEnabled ? "Voice on" : "Voice off"}</span>
+        <span>{voiceEnabled ? "Voix activée" : "Voix coupée"}</span>
       </button>
 
       <button

--- a/src/ui/components/OpeningTreeColumn.tsx
+++ b/src/ui/components/OpeningTreeColumn.tsx
@@ -9,7 +9,7 @@ interface OpeningTreeColumnProps {
 
 const colorLabel: Record<Color, string> = {
   white: "Ses armes avec les Blancs",
-  black: "Ses lignes cote Noirs",
+  black: "Ses lignes côté Noirs",
 };
 
 const formatPercent = (value: number) => `${Math.round(value * 100)}%`;
@@ -20,7 +20,7 @@ export default function OpeningTreeColumn({ color, nodes, activeNodeId, onSelect
       <section className="opening-column opening-column--empty">
         <header>
           <h3>{colorLabel[color]}</h3>
-          <p>Pas assez de parties recentes pour detecter des patterns fiables.</p>
+          <p>Pas assez de parties récentes pour détecter des patterns fiables.</p>
         </header>
       </section>
     );
@@ -32,10 +32,10 @@ export default function OpeningTreeColumn({ color, nodes, activeNodeId, onSelect
     <section className={`opening-column opening-column--${color}`}>
       <header className="opening-column__header">
         <div>
-          <p className="micro-tag">{color === "white" ? "En premiere" : "A la riposte"}</p>
+          <p className="micro-tag">{color === "white" ? "En première" : "À la riposte"}</p>
           <h3>{colorLabel[color]}</h3>
           <p className="opening-column__subtitle">
-            Visualisation abstraite: intensite = frequence, halo = danger potentiel, puces = coups clefs.
+            Visualisation abstraite : intensité = fréquence, halo = danger potentiel, puces = coups clés.
           </p>
         </div>
       </header>
@@ -72,7 +72,7 @@ export default function OpeningTreeColumn({ color, nodes, activeNodeId, onSelect
               <div className="line-card__body">
                 <div className="line-card__titles">
                   <h4>{title}</h4>
-                  <p className="line-card__san">{node.sanLine.join(" ") || "(debut de partie)"}</p>
+                  <p className="line-card__san">{node.sanLine.join(" ") || "(début de partie)"}</p>
                 </div>
                 <div className="line-card__meta">
                   <span>{node.frequency} parties</span>
@@ -96,7 +96,7 @@ export default function OpeningTreeColumn({ color, nodes, activeNodeId, onSelect
                       );
                     })
                   ) : (
-                    <span className="move-chip move-chip--empty">Pas de coup reference</span>
+                    <span className="move-chip move-chip--empty">Pas de coup référencé</span>
                   )}
                 </div>
               </div>

--- a/src/ui/components/PrepSheetView.tsx
+++ b/src/ui/components/PrepSheetView.tsx
@@ -27,8 +27,8 @@ export default function PrepSheetView({ sheet, node }: PrepSheetViewProps) {
   if (!sheet.leaks.length) {
     return (
       <section className="prep-sheet prep-sheet--empty" aria-live="polite">
-        <h2>Pas de fuite majeure dÈtectÈe</h2>
-        <p>Nos heuristiques n'identifient pas de faiblesses flagrantes. Continue ‡ explorer des lignes annexes !</p>
+        <h2>Pas de fuite majeure d√©tect√©e</h2>
+        <p>Nos heuristiques n'identifient pas de faiblesses flagrantes. Continue √† explorer des lignes annexes !</p>
       </section>
     );
   }
@@ -36,12 +36,12 @@ export default function PrepSheetView({ sheet, node }: PrepSheetViewProps) {
   const headerTitle = (node.name ?? node.sanLine.join(" ")) || "ouverture";
 
   return (
-    <section className="prep-sheet" aria-label="Plan d'attaque personnalisÈ">
+    <section className="prep-sheet" aria-label="Plan d'attaque personnalis√©">
       <header className="prep-sheet__header">
-        <p className="micro-tag">Plan ciblÈ</p>
-        <h2>Prep sheet ñ {headerTitle}</h2>
+        <p className="micro-tag">Plan cibl√©</p>
+        <h2>Prep sheet {headerTitle}</h2>
         <p>
-          Chaque carte rÈsume une opportunitÈ : gap de performance, coups recommandÈs, parties modËles. Visualisation abstraite pour un onboarding rapide.
+          Chaque carte r√©sume une opportunit√© : √©cart de performance, coups recommand√©s, parties mod√®les. Visualisation abstraite pour un onboarding rapide.
         </p>
       </header>
 
@@ -61,7 +61,7 @@ export default function PrepSheetView({ sheet, node }: PrepSheetViewProps) {
               ? `${formatPercent(leak.playerScore)} vs ${formatPercent(leak.explorerScore)}`
               : formatPercent(leak.playerScore);
           const overlap = leak.yourOverlap
-            ? `Ton score ${formatPercent(leak.yourOverlap.score)} ∑ ${leak.yourOverlap.frequency} parties`
+            ? `Ton score ${formatPercent(leak.yourOverlap.score)} sur ${leak.yourOverlap.frequency} parties`
             : null;
           const gap = leak.explorerScore !== undefined ? leak.explorerScore - leak.playerScore : null;
           const dangerLevel = Math.min(1, Math.max(0, leak.playerScore));
@@ -90,14 +90,16 @@ export default function PrepSheetView({ sheet, node }: PrepSheetViewProps) {
                   <span className="insight-caption">{leak.reason}</span>
                 </div>
                 <div>
-                  <span className="insight-label">FrÈquence</span>
+                  <span className="insight-label">Fr√©quence</span>
                   <p className="insight-value">{leak.frequency} parties</p>
-                  {popularity !== null && <span className="insight-caption">PopularitÈ explorer {formatPercent(popularity)}</span>}
+                  {popularity !== null && (
+                    <span className="insight-caption">Popularit√© Explorer {formatPercent(popularity)}</span>
+                  )}
                 </div>
                 <div>
                   <span className="insight-label">Gap</span>
                   <p className="insight-value">{leakScoreDiff}</p>
-                  {gap !== null && <span className="insight-caption">…cart {gap > 0 ? "‡ exploiter" : "‡ surveiller"}</span>}
+                  {gap !== null && <span className="insight-caption">√âcart {gap > 0 ? "√† exploiter" : "√† surveiller"}</span>}
                 </div>
               </div>
 
@@ -114,18 +116,18 @@ export default function PrepSheetView({ sheet, node }: PrepSheetViewProps) {
                       </span>
                     ))
                   ) : (
-                    <span className="response-chip response-chip--empty">Pas de rÈf claire</span>
+                    <span className="response-chip response-chip--empty">Pas de r√©f√©rence claire</span>
                   )}
                 </div>
                 <div className="leak-card__links">
                   {leak.sampleGameUrl && (
                     <a href={leak.sampleGameUrl} target="_blank" rel="noreferrer">
-                      Partie tÈmoin
+                      Partie t√©moin
                     </a>
                   )}
                   {leak.lichessRecentGames?.slice(0, 2).map((game) => (
                     <a key={game.id} href={game.url} target="_blank" rel="noreferrer">
-                      ModËle Lichess {game.speed ? `(${game.speed})` : ""}
+                      Mod√®le Lichess {game.speed ? `(${game.speed})` : ""}
                     </a>
                   ))}
                 </div>
@@ -137,7 +139,7 @@ export default function PrepSheetView({ sheet, node }: PrepSheetViewProps) {
 
       {sheet.modelGames.length > 0 && (
         <footer className="prep-sheet__footer">
-          <h3>Parties ‡ dÈcortiquer</h3>
+          <h3>Parties √† d√©cortiquer</h3>
           <div className="model-gallery">
             {sheet.modelGames.slice(0, 6).map((game) => (
               <a key={game.id} href={game.url} target="_blank" rel="noreferrer" className="model-card">

--- a/src/ui/components/UsernameForm.tsx
+++ b/src/ui/components/UsernameForm.tsx
@@ -17,10 +17,10 @@ export default function UsernameForm({ onRun, assistantMessage }: UsernameFormPr
   const isReady = you.trim().length > 0 && opp.trim().length > 0;
 
   const headline = useMemo(() => {
-    if (!you && !opp) return "Un copilote IA pour ta preparation.";
-    if (you && !opp) return "Ton style est charge, qui affrontes-tu ?";
-    if (!you && opp) return "On cible ton adversaire, reste a savoir qui tu es.";
-    return "Prete pour une analyse augmentee ?";
+    if (!you && !opp) return "Un copilote IA pour ta préparation.";
+    if (you && !opp) return "Ton style est chargé, qui affrontes-tu ?";
+    if (!you && opp) return "On cible ton adversaire, reste à savoir qui tu es.";
+    return "Prêt·e pour une analyse augmentée ?";
   }, [you, opp]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -43,17 +43,17 @@ export default function UsernameForm({ onRun, assistantMessage }: UsernameFormPr
     <form className="fusion-card username-form" onSubmit={handleSubmit}>
       <header className="username-form__header">
         <div>
-          <p className="micro-tag">Scouting assiste</p>
+          <p className="micro-tag">Scouting assisté</p>
           <h2>{headline}</h2>
           <p className="username-form__subtitle">
-            Laisse l'IA croiser vos historiques, detecter les fuites et te proposer des reponses ciblees. Interface adaptative, data viz immersive, focus sur l'essentiel.
+            Laisse l'IA croiser tes historiques, détecter les fuites et te proposer des réponses ciblées. Interface adaptative, data viz immersive, focus sur l'essentiel.
           </p>
         </div>
         <div className="username-form__badge" role="status">
           <span aria-hidden>*</span>
           <div>
-            <strong>Analyse en temps reel</strong>
-            <p>Recalibree a chaque recherche, personnalisable.</p>
+            <strong>Analyse en temps réel</strong>
+            <p>Recalibrée à chaque recherche, personnalisable.</p>
           </div>
         </div>
       </header>
@@ -76,7 +76,7 @@ export default function UsernameForm({ onRun, assistantMessage }: UsernameFormPr
         </button>
 
         <label className="floating-label">
-          <span>Pseudo de l'adversaire</span>
+          <span>Pseudo de ton adversaire</span>
           <input
             id="opponent"
             value={opp}
@@ -132,7 +132,7 @@ export default function UsernameForm({ onRun, assistantMessage }: UsernameFormPr
           Lancer l'analyse IA
         </button>
         <p className="micro-copy">
-          Conforme WCAG 2.2 AA. Donnees publiques Chess.com, requetes Lichess a la demande.
+          Conforme WCAG 2.2 AA. Données publiques Chess.com, requêtes Lichess à la demande.
         </p>
       </div>
     </form>

--- a/src/ui/components/VoiceInterface.tsx
+++ b/src/ui/components/VoiceInterface.tsx
@@ -23,21 +23,21 @@ export function VoiceInterface({ status, transcript, assistantMessage, suggestio
 
       <div className="voice-interface__body">
         <p className="voice-interface__status">
-          {status === "idle" && "Assistant pret. Lance-toi."}
-          {status === "listening" && "Je t'ecoute..."}
-          {status === "processing" && "Je reflechis a la meilleure action."}
+          {status === "idle" && "Assistant prêt. Lance-toi."}
+          {status === "listening" && "Je t'écoute..."}
+          {status === "processing" && "Je réfléchis à la meilleure action."}
           {status === "error" && (error ?? "Je n'ai pas compris, retente.")}
         </p>
 
         {transcript && (
-          <div className="voice-interface__transcript" aria-label="Derniere commande vocale">
+          <div className="voice-interface__transcript" aria-label="Dernière commande vocale">
             <span className="voice-interface__pill">Tu</span>
             <p>{transcript}</p>
           </div>
         )}
 
         {assistantMessage && (
-          <div className="voice-interface__response" aria-label="Reponse de l'assistant">
+          <div className="voice-interface__response" aria-label="Réponse de l'assistant">
             <span className="voice-interface__pill voice-interface__pill--ai">IA</span>
             <p>{assistantMessage}</p>
           </div>


### PR DESCRIPTION
## Summary
- modernise les textes de l'écran principal avec des accents corrigés, du tutoiement et un ton plus chaleureux
- mettre à jour les libellés des composants (toolbar, colonne d'ouvertures, interface vocale, fiche de préparation) pour une cohérence linguistique
- rafraîchir le formulaire de pseudos et les messages de statut avec une formulation française naturelle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6826e36483279e5b267ea6a7cf90