### PR TITLE
Add interactive line viewer to opening analysis

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -556,6 +556,270 @@
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
+.line-viewer {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-soft);
+}
+
+.line-viewer__header h3 {
+  margin: 8px 0 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.line-viewer__subtitle {
+  margin: 6px 0 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.line-viewer__body {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(240px, 1fr) minmax(260px, 1.1fr);
+  align-items: start;
+}
+
+.line-viewer__board {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+.line-viewer__board-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  max-width: 320px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  box-shadow: inset 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.line-viewer__square {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1.25rem, 2.2vw, 1.9rem);
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.line-viewer__square.is-light {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.92));
+  color: var(--text-primary);
+}
+
+.line-viewer__square.is-dark {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.28), rgba(71, 85, 105, 0.3));
+  color: var(--text-primary);
+}
+
+.line-viewer__square.is-highlighted {
+  box-shadow: inset 0 0 0 3px rgba(112, 91, 255, 0.55);
+  transform: scale(1.02);
+}
+
+.line-viewer__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.line-viewer__controls button {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-glass);
+  color: var(--text-secondary);
+  font-size: 1.25rem;
+  transition: all 0.2s ease;
+}
+
+.line-viewer__controls button:hover:not(:disabled),
+.line-viewer__controls button:focus-visible {
+  border-color: var(--accent-400);
+  color: var(--accent-500);
+  box-shadow: 0 10px 24px rgba(112, 91, 255, 0.22);
+}
+
+.line-viewer__controls button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.line-viewer__moves {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.line-viewer__moves h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.line-viewer__moves ol {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.line-viewer__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.line-viewer__moves li {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr;
+  gap: 8px;
+  align-items: center;
+}
+
+.line-viewer__move-number {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.line-viewer__move {
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: var(--surface-glass);
+  padding: 6px 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: inline-flex;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.line-viewer__move:hover,
+.line-viewer__move:focus-visible {
+  border-color: rgba(112, 91, 255, 0.45);
+  box-shadow: 0 12px 24px rgba(112, 91, 255, 0.25);
+}
+
+.line-viewer__move.is-active {
+  border-color: var(--accent-500);
+  background: rgba(112, 91, 255, 0.12);
+  color: var(--accent-600, var(--accent-500));
+}
+
+.line-viewer__move.is-empty {
+  background: transparent;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.line-viewer__continuations h4 {
+  margin: 16px 0 8px;
+  font-size: 0.95rem;
+}
+
+.line-viewer__continuations ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.line-viewer__continuation {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid transparent;
+  color: var(--text-primary);
+  text-align: left;
+  transition: all 0.2s ease;
+}
+
+.line-viewer__continuation:hover,
+.line-viewer__continuation:focus-visible {
+  border-color: rgba(112, 91, 255, 0.4);
+  background: rgba(112, 91, 255, 0.12);
+  box-shadow: 0 12px 28px rgba(112, 91, 255, 0.18);
+}
+
+.line-viewer__continuation.is-active {
+  border-color: var(--accent-500);
+  background: rgba(112, 91, 255, 0.18);
+}
+
+.line-viewer__continuation-san {
+  font-weight: 700;
+}
+
+.line-viewer__continuation-share,
+.line-viewer__continuation-score {
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.line-viewer__sample {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.line-viewer__sample a {
+  margin-left: 6px;
+  color: var(--accent-500);
+  font-weight: 600;
+}
+
+.line-viewer__sample a:hover,
+.line-viewer__sample a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 960px) {
+  .line-viewer__body {
+    grid-template-columns: 1fr;
+  }
+
+  .line-viewer__board {
+    align-items: stretch;
+  }
+
+  .line-viewer__board-grid {
+    margin: 0 auto;
+    max-width: 280px;
+  }
+}
+
 
 .opening-column {
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import UsernameForm from "./ui/components/UsernameForm";
 import OpeningTreeColumn from "./ui/components/OpeningTreeColumn";
+import LineViewer from "./ui/components/LineViewer";
 import PrepSheetView from "./ui/components/PrepSheetView";
 import { ExperienceToolbar } from "./ui/components/ExperienceToolbar";
 import { VoiceInterface } from "./ui/components/VoiceInterface";
@@ -736,6 +737,7 @@ export default function App() {
                     onSelect={handleSelectNode}
                   />
                 </div>
+                {selectedNode && <LineViewer node={selectedNode} />}
               </>
             )}
 

--- a/src/ui/components/LineViewer.tsx
+++ b/src/ui/components/LineViewer.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useMemo, useState } from "react";
+import { Chess } from "chess.js";
+import type { OpeningFenNode } from "../../domain/models";
+
+type Orientation = "white" | "black";
+
+type Snapshot = {
+  fen: string;
+  ply: number;
+  san?: string;
+  lastMove?: { from: string; to: string };
+};
+
+const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+
+const PIECE_GLYPHS: Record<string, string> = {
+  p: "♟",
+  r: "♜",
+  n: "♞",
+  b: "♝",
+  q: "♛",
+  k: "♚",
+  P: "♙",
+  R: "♖",
+  N: "♘",
+  B: "♗",
+  Q: "♕",
+  K: "♔",
+};
+
+const formatPercent = (value: number) => `${Math.round(value * 100)}%`;
+
+const parseFenBoard = (fen: string) => {
+  const [placement] = fen.split(" ");
+  const rows = placement.split("/");
+  const board: (string | null)[][] = Array.from({ length: 8 }, () => Array(8).fill(null));
+
+  rows.forEach((row, fenRankIndex) => {
+    let file = 0;
+    for (const char of row) {
+      const emptyCount = Number.parseInt(char, 10);
+      if (!Number.isNaN(emptyCount)) {
+        file += emptyCount;
+        continue;
+      }
+      const rank = 7 - fenRankIndex; // rank 0 is first rank from White's perspective
+      board[rank][file] = char;
+      file += 1;
+    }
+  });
+
+  return board;
+};
+
+const computeBaseSnapshots = (node: OpeningFenNode): Snapshot[] => {
+  const chess = new Chess();
+  const snapshots: Snapshot[] = [
+    {
+      fen: chess.fen(),
+      ply: 0,
+    },
+  ];
+
+  for (const [index, san] of node.sanLine.entries()) {
+    try {
+      const move = chess.move(san);
+      if (!move) break;
+      snapshots.push({
+        fen: chess.fen(),
+        ply: index + 1,
+        san: move.san,
+        lastMove: { from: move.from, to: move.to },
+      });
+    } catch (error) {
+      console.warn("[LineViewer] invalid SAN", san, error);
+      break;
+    }
+  }
+
+  const lastSnapshot = snapshots[snapshots.length - 1];
+  if (!lastSnapshot || lastSnapshot.fen !== node.fen) {
+    try {
+      const chessFromFen = new Chess(node.fen);
+      snapshots.push({
+        fen: chessFromFen.fen(),
+        ply: snapshots.length,
+      });
+    } catch (error) {
+      console.warn("[LineViewer] unable to load node FEN", node.fen, error);
+    }
+  }
+
+  return snapshots;
+};
+
+const computeContinuationSnapshot = (node: OpeningFenNode, san: string | null, startPly: number): Snapshot[] => {
+  if (!san) return [];
+  try {
+    const chess = new Chess(node.fen);
+    const move = chess.move(san);
+    if (!move) return [];
+    return [
+      {
+        fen: chess.fen(),
+        ply: startPly,
+        san: move.san,
+        lastMove: { from: move.from, to: move.to },
+      },
+    ];
+  } catch (error) {
+    console.warn("[LineViewer] invalid continuation", san, error);
+    return [];
+  }
+};
+
+const buildMovePairs = (moves: string[]) => {
+  const pairs: Array<{ moveNumber: number; white?: string; black?: string }> = [];
+  for (let i = 0; i < moves.length; i += 2) {
+    pairs.push({
+      moveNumber: Math.floor(i / 2) + 1,
+      white: moves[i],
+      black: moves[i + 1],
+    });
+  }
+  return pairs;
+};
+
+const squareKey = (file: number, rank: number) => `${FILES[file]}${rank + 1}`;
+
+const MiniBoard = ({
+  fen,
+  orientation,
+  highlight,
+}: {
+  fen: string;
+  orientation: Orientation;
+  highlight?: string[];
+}) => {
+  const board = useMemo(() => parseFenBoard(fen), [fen]);
+  const highlightSet = useMemo(() => new Set((highlight ?? []).map((sq) => sq.toLowerCase())), [highlight]);
+  const rankOrder = orientation === "white" ? [7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7];
+  const fileOrder = orientation === "white" ? [0, 1, 2, 3, 4, 5, 6, 7] : [7, 6, 5, 4, 3, 2, 1, 0];
+
+  return (
+    <div className="line-viewer__board-grid" role="img" aria-label={`Position après ${fen}`}> 
+      {rankOrder.map((rank) =>
+        fileOrder.map((file) => {
+          const piece = board[rank][file];
+          const algebraic = squareKey(file, rank);
+          const isLight = (file + rank) % 2 === 0;
+          const isHighlighted = highlightSet.has(algebraic);
+          return (
+            <span
+              key={`${algebraic}-${fen}`}
+              className={`line-viewer__square${isLight ? " is-light" : " is-dark"}${
+                isHighlighted ? " is-highlighted" : ""
+              }`}
+              aria-label={`${algebraic}${piece ? ` ${piece}` : ""}`}
+            >
+              {piece ? PIECE_GLYPHS[piece] : ""}
+            </span>
+          );
+        })
+      )}
+    </div>
+  );
+};
+
+export function LineViewer({ node }: { node: OpeningFenNode }) {
+  const [selectedContinuation, setSelectedContinuation] = useState<string | null>(null);
+  const baseSnapshots = useMemo(() => computeBaseSnapshots(node), [node]);
+  const continuationSnapshots = useMemo(
+    () => computeContinuationSnapshot(node, selectedContinuation, baseSnapshots.length),
+    [node, selectedContinuation, baseSnapshots.length]
+  );
+  const snapshots = useMemo(() => [...baseSnapshots, ...continuationSnapshots], [baseSnapshots, continuationSnapshots]);
+  const [cursor, setCursor] = useState(() => Math.max(0, snapshots.length - 1));
+
+  useEffect(() => {
+    setSelectedContinuation(null);
+  }, [node.id]);
+
+  useEffect(() => {
+    setCursor(Math.max(0, baseSnapshots.length - 1));
+  }, [node.id, baseSnapshots.length]);
+
+  useEffect(() => {
+    setCursor((prev) => Math.min(prev, Math.max(0, snapshots.length - 1)));
+  }, [snapshots.length]);
+
+  useEffect(() => {
+    if (selectedContinuation) {
+      setCursor(Math.max(0, snapshots.length - 1));
+    }
+  }, [selectedContinuation, snapshots.length]);
+
+  const displayedMoves = useMemo(
+    () => (selectedContinuation ? [...node.sanLine, selectedContinuation] : node.sanLine),
+    [node.sanLine, selectedContinuation]
+  );
+
+  const movePairs = useMemo(() => buildMovePairs(displayedMoves), [displayedMoves]);
+  const fallbackTitle = useMemo(() => {
+    const joined = node.sanLine.slice(0, 4).join(" ").trim();
+    return joined || "Ligne sans nom";
+  }, [node.sanLine]);
+  const title = node.name ?? fallbackTitle;
+
+  const activeSnapshot = snapshots[cursor];
+  const activeMoveIndex = Math.min(displayedMoves.length - 1, Math.max(-1, cursor - 1));
+  const orientation: Orientation = node.color === "black" ? "black" : "white";
+  const highlightSquares = activeSnapshot?.lastMove
+    ? [activeSnapshot.lastMove.from, activeSnapshot.lastMove.to]
+    : undefined;
+
+  const goTo = (nextCursor: number) => {
+    setCursor(Math.max(0, Math.min(nextCursor, Math.max(0, snapshots.length - 1))));
+  };
+
+  const toggleContinuation = (san: string) => {
+    setSelectedContinuation((prev) => (prev === san ? null : san));
+  };
+
+  return (
+    <section className="line-viewer">
+      <header className="line-viewer__header">
+        <div>
+          <p className="micro-tag">Visualisation de la ligne</p>
+          <h3>{title}</h3>
+          <p className="line-viewer__subtitle">
+            {node.eco ? `ECO ${node.eco} – ` : ""}
+            {node.frequency} parties récentes. Score adverse moyen {formatPercent(node.score)}.
+          </p>
+        </div>
+      </header>
+
+      <div className="line-viewer__body">
+        <div className="line-viewer__board">
+          {activeSnapshot && (
+            <MiniBoard fen={activeSnapshot.fen} orientation={orientation} highlight={highlightSquares} />
+          )}
+          <div className="line-viewer__controls" aria-label="Contrôles de navigation de la ligne">
+            <button type="button" onClick={() => goTo(0)} disabled={cursor === 0}>
+              «
+            </button>
+            <button type="button" onClick={() => goTo(cursor - 1)} disabled={cursor === 0}>
+              ‹
+            </button>
+            <span>
+              {cursor}/{Math.max(0, snapshots.length - 1)}
+            </span>
+            <button type="button" onClick={() => goTo(cursor + 1)} disabled={cursor >= snapshots.length - 1}>
+              ›
+            </button>
+            <button type="button" onClick={() => goTo(snapshots.length - 1)} disabled={cursor >= snapshots.length - 1}>
+              »
+            </button>
+          </div>
+        </div>
+
+        <div className="line-viewer__moves" aria-live="polite">
+          <h4>Rejeu rapide</h4>
+          {movePairs.length ? (
+            <ol>
+              {movePairs.map((pair) => {
+                const whiteIndex = (pair.moveNumber - 1) * 2;
+                const blackIndex = whiteIndex + 1;
+                const isWhiteActive = whiteIndex === activeMoveIndex;
+                const isBlackActive = blackIndex === activeMoveIndex;
+                return (
+                  <li key={pair.moveNumber}>
+                    <span className="line-viewer__move-number">{pair.moveNumber}.</span>
+                    {pair.white ? (
+                      <button
+                        type="button"
+                        className={`line-viewer__move${isWhiteActive ? " is-active" : ""}`}
+                        onClick={() => goTo(whiteIndex + 1)}
+                      >
+                        {pair.white}
+                      </button>
+                    ) : (
+                      <span className="line-viewer__move is-empty">…</span>
+                    )}
+                    {pair.black ? (
+                      <button
+                        type="button"
+                        className={`line-viewer__move${isBlackActive ? " is-active" : ""}`}
+                        onClick={() => goTo(blackIndex + 1)}
+                      >
+                        {pair.black}
+                      </button>
+                    ) : (
+                      <span className="line-viewer__move is-empty">—</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          ) : (
+            <p className="line-viewer__empty">Position initiale : aucun coup enregistré pour le moment.</p>
+          )}
+
+          {node.moveSamples.length > 0 && (
+            <div className="line-viewer__continuations">
+              <h4>Réponses adverses fréquentes</h4>
+              <ul>
+                {node.moveSamples.slice(0, 6).map((move) => {
+                  const share = move.count / Math.max(1, node.frequency);
+                  const averageScore = move.count ? move.scoreSum / move.count : 0;
+                  const isActive = selectedContinuation === move.san;
+                  return (
+                    <li key={move.san}>
+                      <button
+                        type="button"
+                        className={`line-viewer__continuation${isActive ? " is-active" : ""}`}
+                        onClick={() => toggleContinuation(move.san)}
+                      >
+                        <span className="line-viewer__continuation-san">{move.san}</span>
+                        <span className="line-viewer__continuation-share">{formatPercent(share)}</span>
+                        <span className="line-viewer__continuation-score">{formatPercent(averageScore)}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {node.sampleGameUrl && (
+        <p className="line-viewer__sample">
+          Partie modèle :
+          <a href={node.sampleGameUrl} target="_blank" rel="noreferrer">
+            Voir sur la plateforme source
+          </a>
+        </p>
+      )}
+    </section>
+  );
+}
+
+export default LineViewer;


### PR DESCRIPTION
## Summary
- add a LineViewer component that reconstructs positions with chess.js and replays moves with highlighted squares
- render the viewer alongside the opening columns so selected lines can be inspected with navigation controls and continuations
- style the viewer with board, move list, and continuation chips for a lichess-like experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de896f9e2c8327998f48cc4ddc357c